### PR TITLE
fixes heap corruption if sizeof(enum fann_activationfunc_enum) < sizeof(...

### DIFF
--- a/src/fann_io.c
+++ b/src/fann_io.c
@@ -488,12 +488,13 @@ struct fann *fann_create_from_fd(FILE * conf, const char *configuration_file)
 	fann_skip("cascade_activation_functions=");
 	for(i = 0; i < ann->cascade_activation_functions_count; i++)
 	{
-		if(fscanf(conf, "%u ", (unsigned int *)&ann->cascade_activation_functions[i]) != 1)
+		if(fscanf(conf, "%u ", &tmpVal) != 1)
 		{
 			fann_error(NULL, FANN_E_CANT_READ_CONFIG, "cascade_activation_functions", configuration_file);
 			fann_destroy(ann);
 			return NULL;
 		}
+		ann->cascade_activation_functions[i] = (enum fann_activationfunc_enum)tmpVal;
 	}
 
 	fann_scanf("%u", "cascade_activation_steepnesses_count", &ann->cascade_activation_steepnesses_count);


### PR DESCRIPTION
...unsigned int), e.g. -fshort-enums
