### PR TITLE
Fixing FANN::neural_net copy constructor

### DIFF
--- a/src/include/fann_cpp.h
+++ b/src/include/fann_cpp.h
@@ -854,7 +854,7 @@ public:
 	    See also:
 	    		<copy_from_struct_fann>
         */
-	neural_net(const neural_net& other)
+	neural_net(const neural_net& other) : ann(NULL)
 	{
 	    copy_from_struct_fann(other.ann);
 	}


### PR DESCRIPTION
There is a bug in the FANN::neural_net copy constructor. The newly constructed object does not have a proper pointer at this->ann. The function copy_from_struct_fann(), which is called from within the copy constructor, calls destroy(), which might try to access this->ann (an invalid pointer).

Solution: set this->ann to NULL.
