### PR TITLE
Remove redundant file compat-time.h

### DIFF
--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -1,4 +1,4 @@
 ########### install files ###############
 
-INSTALL_FILES( /include FILES  fann.h doublefann.h fann_internal.h floatfann.h fann_data.h fixedfann.h compat_time.h fann_activation.h fann_cascade.h fann_error.h fann_train.h fann_io.h fann_cpp.h )
+INSTALL_FILES( /include FILES  fann.h doublefann.h fann_internal.h floatfann.h fann_data.h fixedfann.h fann_activation.h fann_cascade.h fann_error.h fann_train.h fann_io.h fann_cpp.h )
 


### PR DESCRIPTION
To eliminate the error when install the library.
