### PR TITLE
introduce regularisation parameters

### DIFF
--- a/src/fann.c
+++ b/src/fann.c
@@ -900,6 +900,8 @@ FANN_EXTERNAL struct fann* FANN_API fann_copy(struct fann* orig)
 
     copy->learning_rate = orig->learning_rate;
     copy->learning_momentum = orig->learning_momentum;
+    copy->learning_l1_norm = orig->learning_l1_norm;
+    copy->learning_l2_norm = orig->learning_l2_norm;
     copy->connection_rate = orig->connection_rate;
     copy->network_type = orig->network_type;
     copy->num_MSE = orig->num_MSE;
@@ -1288,6 +1290,8 @@ FANN_EXTERNAL void FANN_API fann_print_parameters(struct fann *ann)
 	printf("Bit fail limit                       :%8.3f\n", ann->bit_fail_limit);
 	printf("Learning rate                        :%8.3f\n", ann->learning_rate);
 	printf("Learning momentum                    :%8.3f\n", ann->learning_momentum);
+	printf("Learning l1 norm                     :%8.3f\n", ann->learning_l1_norm);
+	printf("Learning l2 norm                     :%8.3f\n", ann->learning_l2_norm);
 	printf("Quickprop decay                      :%11.6f\n", ann->quickprop_decay);
 	printf("Quickprop mu                         :%8.3f\n", ann->quickprop_mu);
 	printf("RPROP increase factor                :%8.3f\n", ann->rprop_increase_factor);
@@ -1589,6 +1593,8 @@ struct fann *fann_allocate_structure(unsigned int num_layers)
 	ann->errstr = NULL;
 	ann->learning_rate = 0.7f;
 	ann->learning_momentum = 0.0;
+	ann->learning_l1_norm = 0.0;
+	ann->learning_l2_norm = 1.0;
 	ann->total_neurons = 0;
 	ann->total_connections = 0;
 	ann->num_input = 0;

--- a/src/fann.c
+++ b/src/fann.c
@@ -790,12 +790,20 @@ FANN_EXTERNAL fann_type *FANN_API fann_run(struct fann * ann, fann_type * input)
 #else
 			neuron_sum = fann_mult(steepness, neuron_sum);
 			
-			max_sum = 150/steepness;
-			if(neuron_sum > max_sum)
-				neuron_sum = max_sum;
-			else if(neuron_sum < -max_sum)
-				neuron_sum = -max_sum;
-			
+			switch (activation_function)
+			{
+				case FANN_LINEAR:
+					break;
+				default:
+
+					max_sum = 150/steepness;
+					if(neuron_sum > max_sum)
+						neuron_sum = max_sum;
+					else if(neuron_sum < -max_sum)
+						neuron_sum = -max_sum;
+					break;
+			}
+
 			neuron_it->sum = neuron_sum;
 
 			fann_activation_switch(activation_function, neuron_sum, neuron_it->value);

--- a/src/fann_io.c
+++ b/src/fann_io.c
@@ -181,6 +181,8 @@ int fann_save_internal_fd(struct fann *ann, FILE * conf, const char *configurati
 	fprintf(conf, "network_type=%u\n", ann->network_type);
 	
 	fprintf(conf, "learning_momentum=%f\n", ann->learning_momentum);
+	fprintf(conf, "learning_l1_norm=%f\n", ann->learning_l1_norm);
+	fprintf(conf, "learning_l2_norm=%f\n", ann->learning_l2_norm);
 	fprintf(conf, "training_algorithm=%u\n", ann->training_algorithm);
 	fprintf(conf, "train_error_function=%u\n", ann->train_error_function);
 	fprintf(conf, "train_stop_function=%u\n", ann->train_stop_function);
@@ -443,6 +445,8 @@ struct fann *fann_create_from_fd(FILE * conf, const char *configuration_file)
 	fann_scanf("%u", "network_type", &tmpVal);
 	ann->network_type = (enum fann_nettype_enum)tmpVal;
 	fann_scanf("%f", "learning_momentum", &ann->learning_momentum);
+	fann_scanf("%f", "learning_l1_norm", &ann->learning_l1_norm);
+	fann_scanf("%f", "learning_l2_norm", &ann->learning_l2_norm);
 	fann_scanf("%u", "training_algorithm", &tmpVal);
 	ann->training_algorithm = (enum fann_train_enum)tmpVal;
 	fann_scanf("%u", "train_error_function", &tmpVal);

--- a/src/fann_train.c
+++ b/src/fann_train.c
@@ -377,7 +377,9 @@ void fann_update_weights(struct fann *ann)
 
 	/* store some variabels local for fast access */
 	const float learning_rate = ann->learning_rate;
-    const float learning_momentum = ann->learning_momentum;        
+    const float learning_momentum = ann->learning_momentum;  
+    const float learning_l1_norm = ann->learning_l1_norm; 
+    const float learning_l2_norm = ann->learning_l2_norm;       
 	struct fann_neuron *first_neuron = ann->first_layer->first_neuron;
 	struct fann_layer *first_layer = ann->first_layer;
 	const struct fann_layer *last_layer = ann->last_layer;
@@ -422,6 +424,15 @@ void fann_update_weights(struct fann *ann)
 				for(i = 0; i != num_connections; i++)
 				{
 					delta_w = tmp_error * prev_neurons[i].value + learning_momentum * weights_deltas[i];
+					weights[i] *= learning_l2_norm ;
+					if(fann_abs(weights[i])  <= learning_l1_norm)
+					{
+						weights[i] = 0.0 ;
+					}
+					else
+					{
+						weights[i] -= learning_l1_norm * (weights[i] / fann_abs(weights[i])) ;
+					}
 					weights[i] += delta_w ;
 					weights_deltas[i] = delta_w;
 				}
@@ -438,6 +449,15 @@ void fann_update_weights(struct fann *ann)
 				for(i = 0; i != num_connections; i++)
 				{
 					delta_w = tmp_error * prev_neurons[i].value + learning_momentum * weights_deltas[i];
+					weights[i] *= learning_l2_norm ;
+					if(fann_abs(weights[i])  <= learning_l1_norm)
+					{
+						weights[i]= 0.0 ;
+					}
+					else
+					{
+						weights[i] -= learning_l1_norm * (weights[i] / fann_abs(weights[i])) ;
+					}
 					weights[i] += delta_w;
 					weights_deltas[i] = delta_w;
 				}
@@ -1045,3 +1065,5 @@ FANN_GET_SET(float, sarprop_temperature)
 FANN_GET_SET(enum fann_stopfunc_enum, train_stop_function)
 FANN_GET_SET(fann_type, bit_fail_limit)
 FANN_GET_SET(float, learning_momentum)
+FANN_GET_SET(float, learning_l1_norm)
+FANN_GET_SET(float, learning_l2_norm)

--- a/src/include/config.h
+++ b/src/include/config.h
@@ -2,7 +2,7 @@
 /* #undef PACKAGE */
 
 /* Version number of package */
-#define VERSION "2.2.0"
+/* #undef VERSION */
 
 /* Define for the x86_64 CPU famyly */
 /* #undef X86_64 */

--- a/src/include/fann_cpp.h
+++ b/src/include/fann_cpp.h
@@ -2648,13 +2648,97 @@ public:
 
            More info available in <get_learning_momentum>
 
-           This function appears in FANN >= 2.0.0.   	
+           This function appears in FANN >= 2.0.0.      
          */ 
         void set_learning_momentum(float learning_momentum)
         {
             if (ann != NULL)
             {
                 fann_set_learning_momentum(ann, learning_momentum);
+            }
+        }
+
+        /* Method: get_learning_l1_norm
+
+           Get the learning l1 norm.
+           
+           The learning l1 norm can be used to regulate FANN::TRAIN_INCREMENTAL training.
+           A too high l1 norm will however not benefit training. Setting l1 norm to 0 will
+           be the same as not using the l1 norm parameter. The recommended value of this parameter
+           is between 0.0 and 1.0.
+
+           The default l1 norm is 0.
+           
+           See also:
+           <set_learning_l1_norm>, <set_training_algorithm>
+
+           This function appears in FANN >= 2.0.0.      
+         */ 
+        float get_learning_l1_norm()
+        {
+            float learning_l1_norm = 0.0f;
+            if (ann != NULL)
+            {
+                learning_l1_norm = fann_get_learning_l1_norm(ann);
+            }
+            return learning_l1_norm;
+        }
+
+        /* Method: set_learning_l1_norm
+
+           Set the learning l1 norm.
+
+           More info available in <get_learning_l1_norm>
+
+           This function appears in FANN >= 2.0.0.   	
+         */ 
+        void set_learning_l1_norm(float learning_l1_norm)
+        {
+            if (ann != NULL)
+            {
+                fann_set_learning_l1_norm(ann, learning_l1_norm);
+            }
+        }
+
+        /* Method: get_learning_l2_norm
+
+           Get the learning l2 norm.
+           
+           The learning l2 norm can be used to regulate FANN::TRAIN_INCREMENTAL training.
+           A too high l2 norm will however not benefit training. Setting l2 norm to 1.0 will
+           be the same as not using the l2 norm parameter. The recommended value of this parameter
+           is between 0.0 and 1.0.
+
+           The default l2 norm is 0.
+           
+           See also:
+           <set_learning_l2_norm>, <set_training_algorithm>
+
+           This function appears in FANN >= 2.0.0.      
+         */ 
+        float get_learning_l2_norm()
+        {
+            float learning_l2_norm = 1.0f;
+            if (ann != NULL)
+            {
+                learning_l2_norm = fann_get_learning_l2_norm(ann);
+            }
+            return learning_l2_norm;
+        }
+
+        /* Method: set_learning_l2_norm
+
+           Set the learning l2 norm.
+
+           More info available in <get_learning_l2_norm>
+
+           This function appears in FANN >= 2.0.0.      
+         */ 
+        void set_learning_l2_norm(float learning_l2_norm)
+        {
+            if (ann != NULL)
+            {
+                fann_set_learning_l2_norm(ann, learning_l2_norm);
             }
         }
 
@@ -2667,7 +2751,7 @@ public:
            The default stop function is FANN::STOPFUNC_MSE
            
            See also:
-   	        <get_train_stop_function>, <get_bit_fail_limit>
+            <get_train_stop_function>, <get_bit_fail_limit>
               
            This function appears in FANN >= 2.0.0.
          */ 

--- a/src/include/fann_data.h
+++ b/src/include/fann_data.h
@@ -490,6 +490,10 @@ struct fann
 	/* The learning momentum used for backpropagation algorithm. */
 	float learning_momentum;
 
+        /* The learning regularisations used for backpropagation algorithm. */
+        float learning_l1_norm;
+        float learning_l2_norm;
+
 	/* the connection rate of the network
 	 * between 0 and 1, 1 meaning fully connected
 	 */

--- a/src/include/fann_train.h
+++ b/src/include/fann_train.h
@@ -766,7 +766,63 @@ FANN_EXTERNAL float FANN_API fann_get_learning_momentum(struct fann *ann);
  */ 
 FANN_EXTERNAL void FANN_API fann_set_learning_momentum(struct fann *ann, float learning_momentum);
 
+/* Function: fann_get_learning_l1_norm
 
+   Get the learning l1 norm.
+   
+   The learning l1 norm can be used to regulate FANN_TRAIN_INCREMENTAL training.
+   A too high l1 norm will however not benefit training. Setting l1 norm to 0 will
+   be the same as not using the l1 norm parameter. The recommended value of this parameter
+   is between 0.0 and 1.0.
+
+   The default l1 norm is 0.
+   
+   See also:
+   <fann_set_learning_l1_norm>, <fann_set_training_algorithm>
+
+   This function appears in FANN >= 2.0.0.    
+ */ 
+FANN_EXTERNAL float FANN_API fann_get_learning_l1_norm(struct fann *ann);
+
+
+/* Function: fann_set_learning_l1_norm
+
+   Set the learning l1 norm.
+
+   More info available in <fann_get_learning_l1_norm>
+
+   This function appears in FANN >= 2.0.0.    
+ */ 
+FANN_EXTERNAL void FANN_API fann_set_learning_l1_norm(struct fann *ann, float learning_l1_norm);
+
+/* Function: fann_get_learning_l2_norm
+
+   Get the learning l2 norm.
+   
+   The learning l2 norm can be used to regulate FANN_TRAIN_INCREMENTAL training.
+   A too high l2 norm will however not benefit training. Setting l2 norm to 1.0 will
+   be the same as not using the l2 norm parameter. The recommended value of this parameter
+   is between 0.0 and 1.0.
+
+   The default l2 norm is 1.0.
+   
+   See also:
+   <fann_set_learning_l2_norm>, <fann_set_training_algorithm>
+
+   This function appears in FANN >= 2.0.0.    
+ */ 
+FANN_EXTERNAL float FANN_API fann_get_learning_l2_norm(struct fann *ann);
+
+
+/* Function: fann_set_learning_l2_norm
+
+   Set the learning l2 norm.
+
+   More info available in <fann_get_learning_l2_norm>
+
+   This function appears in FANN >= 2.0.0.    
+ */ 
+FANN_EXTERNAL void FANN_API fann_set_learning_l2_norm(struct fann *ann, float learning_l2_norm);
 /* Function: fann_get_activation_function
 
    Get the activation function for neuron number *neuron* in layer number *layer*, 


### PR DESCRIPTION
Often when training neural networks it can be beneficial to penalise large weights within the network so as to prevent overfitting. In this pull request I have implemented both l1 norm and l2 norm regularisation parameters.
