### PR TITLE
Fix cmake-config.cmake generation for old (<=2.8.8) CMake versions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,7 @@ if (UNIX)
 endif ()
 
 if (CMAKE_VERSION VERSION_LESS 2.8.8)
-  configure_file (cmake/fann-config.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/fann-config.cmake.cmake @ONLY)
+  configure_file (cmake/fann-config.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/fann-config.cmake @ONLY)
 else ()
 
   include (CMakePackageConfigHelpers)


### PR DESCRIPTION
A typo in the CMakeLists.txt was preventing the installation process to be run successfully since the cmake-config.cmake file was generated with a different filename.