### PR TITLE
Build parallel

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,15 @@
+FIND_PACKAGE(OpenMP)
+IF(OPENMP_FOUND)
+  OPTION(DISABLE_PARALLEL_FANN "Disable parallel fann functions" OFF)
+ENDIF(OPENMP_FOUND)
+
+IF(NOT OPENMP_FOUND OR DISABLE_PARALLEL_FANN)
+  ADD_DEFINITIONS(-DDISABLE_PARALLEL_FANN)
+ELSE()
+  SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+ENDIF(NOT OPENMP_FOUND OR DISABLE_PARALLEL_FANN)
+
 ADD_SUBDIRECTORY( include ) 
 
 INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/src/include)
@@ -9,6 +21,7 @@ endif (WIN32)
 
 SET(floatfann_LIB_SRCS
 floatfann.c
+parallel_floatfann_cpp.cpp
 )
 
 ADD_LIBRARY(floatfann ${floatfann_LIB_SRCS})
@@ -23,6 +36,7 @@ INSTALL(TARGETS floatfann LIBRARY DESTINATION ${LIB_INSTALL_DIR}
 
 SET(doublefann_LIB_SRCS
 doublefann.c
+parallel_doublefann_cpp.cpp
 )
 
 ADD_LIBRARY(doublefann ${doublefann_LIB_SRCS})
@@ -53,6 +67,7 @@ INSTALL(TARGETS fixedfann LIBRARY DESTINATION ${LIB_INSTALL_DIR}
 
 SET(fann_LIB_SRCS
 floatfann.c
+parallel_floatfann_cpp.cpp
 )
 
 ADD_LIBRARY(fann ${fann_LIB_SRCS})

--- a/src/floatfann.c
+++ b/src/floatfann.c
@@ -28,3 +28,4 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "fann_train_data.c"
 #include "fann_error.c"
 #include "fann_cascade.c"
+#include "parallel_fann.c"

--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -1,4 +1,10 @@
 ########### install files ###############
 
-install (FILES fann.h doublefann.h fann_internal.h floatfann.h fann_data.h fixedfann.h fann_activation.h fann_cascade.h fann_error.h fann_train.h fann_io.h fann_cpp.h DESTINATION ${INCLUDE_INSTALL_DIR})
+IF(NOT OPENMP_FOUND OR DISABLE_PARALLEL_FANN)
+  SET(PARALLEL_INCLUDES "")
+ELSE(NOT OPENMP_FOUND OR DISABLE_PARALLEL_FANN)
+  SET(PARALLEL_INCLUDES parallel_fann.h parallel_fann.hpp)
+ENDIF(NOT OPENMP_FOUND OR DISABLE_PARALLEL_FANN)
+
+install (FILES fann.h doublefann.h fann_internal.h floatfann.h fann_data.h fixedfann.h fann_activation.h fann_cascade.h fann_error.h fann_train.h fann_io.h fann_cpp.h ${PARALLEL_INCLUDES} DESTINATION ${INCLUDE_INSTALL_DIR})
 

--- a/src/include/parallel_fann.h
+++ b/src/include/parallel_fann.h
@@ -9,6 +9,16 @@
 
 #include <fann.h>
 
+#ifdef __cplusplus
+extern "C"
+{
+	
+#ifndef __cplusplus
+} /* to fool automatic indention engines */ 
+#endif
+#endif	/* __cplusplus */
+
+#ifndef FIXEDFANN
 FANN_EXTERNAL float FANN_API fann_train_epoch_batch_parallel(struct fann *ann, struct fann_train_data *data, const unsigned int threadnumb);
 
 FANN_EXTERNAL float FANN_API fann_train_epoch_irpropm_parallel(struct fann *ann, struct fann_train_data *data, const unsigned int threadnumb);
@@ -20,6 +30,16 @@ FANN_EXTERNAL float FANN_API fann_train_epoch_sarprop_parallel(struct fann *ann,
 FANN_EXTERNAL float FANN_API fann_train_epoch_incremental_mod(struct fann *ann, struct fann_train_data *data);
 
 FANN_EXTERNAL float FANN_API fann_test_data_parallel(struct fann *ann, struct fann_train_data *data, const unsigned int threadnumb);
+#endif /* FIXEDFANN */
+
+#ifdef __cplusplus
+#ifndef __cplusplus
+/* to fool automatic indention engines */ 
+{
+	
+#endif
+} 
+#endif	/* __cplusplus */
 
 #endif /* PARALLEL_FANN_H_ */
 #endif /* DISABLE_PARALLEL_FANN */

--- a/src/include/parallel_fann.hpp
+++ b/src/include/parallel_fann.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <fann.h>
 
+#ifndef FIXEDFANN
 namespace parallel_fann {
 float train_epoch_batch_parallel(struct fann *ann, struct fann_train_data *data, const unsigned int threadnumb);
 
@@ -33,5 +34,6 @@ float train_epoch_incremental_mod(struct fann *ann, struct fann_train_data *data
 float test_data_parallel(struct fann *ann, struct fann_train_data *data, const unsigned int threadnumb);
 float test_data_parallel(struct fann *ann, struct fann_train_data *data, const unsigned int threadnumb, std::vector< std::vector<fann_type> >& predicted_outputs);
 }
+#endif /* FIXEDFANN */
 #endif /* PARALLEL_FANN_HPP_ */
 #endif /* DISABLE_PARALLEL_FANN */

--- a/src/parallel_doublefann_cpp.cpp
+++ b/src/parallel_doublefann_cpp.cpp
@@ -19,13 +19,9 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 /* Easy way to allow for build of multiple binaries */
 
+#ifndef DISABLE_PARALLEL_FANN
 #include "config.h"
 #include "doublefann.h"
 
-#include "fann.c"
-#include "fann_io.c"
-#include "fann_train.c"
-#include "fann_train_data.c"
-#include "fann_error.c"
-#include "fann_cascade.c"
-#include "parallel_fann.c"
+#include "parallel_fann_cpp.cpp"
+#endif /* DISABLE_PARALLEL_FANN */

--- a/src/parallel_floatfann_cpp.cpp
+++ b/src/parallel_floatfann_cpp.cpp
@@ -19,13 +19,9 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 /* Easy way to allow for build of multiple binaries */
 
+#ifndef DISABLE_PARALLEL_FANN
 #include "config.h"
-#include "doublefann.h"
+#include "floatfann.h"
 
-#include "fann.c"
-#include "fann_io.c"
-#include "fann_train.c"
-#include "fann_train_data.c"
-#include "fann_error.c"
-#include "fann_cascade.c"
-#include "parallel_fann.c"
+#include "parallel_fann_cpp.cpp"
+#endif /* DISABLE_PARALLEL_FANN */


### PR DESCRIPTION
Build the parallel functions (in parallel_fann.c and parallel_fann.cpp) by default on CMake.
This can be deactivated with the DISABLE_PARALLEL_FANN option or if OpenMP is not found.

parallel_fann.h/.hpp still need to be included to use the functions.