### PR TITLE
Remove redundant cast

### DIFF
--- a/src/fann_train.c
+++ b/src/fann_train.c
@@ -789,7 +789,7 @@ void fann_update_weights_sarprop(struct fann *ann, unsigned int epoch, unsigned 
 	float step_error_shift = ann->sarprop_step_error_shift; /* ld 3 = 1.585 */
 	float T = ann->sarprop_temperature;
 	float MSE = fann_get_MSE(ann);
-	float RMSE = (float)sqrt(MSE);
+	float RMSE = sqrtf(MSE);
 
 	unsigned int i = first_weight;
 

--- a/src/fann_train_data.c
+++ b/src/fann_train_data.c
@@ -1154,7 +1154,7 @@ FANN_EXTERNAL void FANN_API fann_descale_train( struct fann *ann, struct fann_tr
 				); 																						\
 	for( cur_neuron = 0; cur_neuron < ann->num_##where##put; cur_neuron++ )								\
 		ann->scale_deviation_##where[ cur_neuron ] =													\
-			(float)sqrt( ann->scale_deviation_##where[ cur_neuron ] / (float)data->num_data ); 			\
+			sqrtf( ann->scale_deviation_##where[ cur_neuron ] / (float)data->num_data ); 			\
 	/* Calculate factor: (new_max-new_min)/(old_max(1)-old_min(-1)) */									\
 	/* Looks like we dont need whole array of factors? */												\
 	for( cur_neuron = 0; cur_neuron < ann->num_##where##put; cur_neuron++ )								\

--- a/src/parallel_fann.c
+++ b/src/parallel_fann.c
@@ -406,7 +406,7 @@ FANN_EXTERNAL float FANN_API fann_train_epoch_sarprop_parallel(struct fann *ann,
     	}
 
     	MSE = fann_get_MSE(ann);
-    	RMSE = (float)sqrt(MSE);
+    	RMSE = sqrtf(MSE);
 
     	/* for all weights; TODO: are biases included? */
 		omp_set_dynamic(0);

--- a/src/parallel_fann_cpp.cpp
+++ b/src/parallel_fann_cpp.cpp
@@ -398,7 +398,7 @@ float fann_train_epoch_sarprop_parallel(struct fann *ann, struct fann_train_data
     	}
 
     	const float MSE = fann_get_MSE(ann);
-    	const float RMSE = (float)sqrt(MSE);
+    	const float RMSE = sqrtf(MSE);
 
     	/* for all weights; TODO: are biases included? */
 		omp_set_dynamic(0);


### PR DESCRIPTION
sqrtf is faster than (float)sqrt.
This is caused by cast cost.
sqrt needs to cast float to double for input and double to float for result.