### PR TITLE
Make fann_default_error_log visible externally to avoid unresolved ex…

### DIFF
--- a/src/fann_error.c
+++ b/src/fann_error.c
@@ -43,8 +43,7 @@
 #endif
 #endif
 
-
-FILE * fann_default_error_log = (FILE *)-1;
+FANN_EXTERNAL extern FILE * FANN_API fann_default_error_log = (FILE *)-1;
 
 /* resets the last error number
  */

--- a/src/include/fann_error.h
+++ b/src/include/fann_error.h
@@ -162,6 +162,6 @@ FANN_EXTERNAL char *FANN_API fann_get_errstr(struct fann_error *errdat);
  */ 
 FANN_EXTERNAL void FANN_API fann_print_error(struct fann_error *errdat);
 
-extern FILE * fann_default_error_log;
+FANN_EXTERNAL extern FILE * fann_default_error_log;
 
 #endif


### PR DESCRIPTION
When trying to link against fann libs on windows I get an unresolved external symbol error for fann_default_error_log. I added FANN_EXTERNAL to both the declaration and definition to resolve the problem.