### PR TITLE
Added more #ifndef FIXEDFAN directives around code that should be excluded from FIXEDFANN

### DIFF
--- a/src/fann.c
+++ b/src/fann.c
@@ -904,6 +904,8 @@ FANN_EXTERNAL struct fann* FANN_API fann_copy(struct fann* orig)
     copy->train_stop_function = orig->train_stop_function;
 	copy->training_algorithm = orig->training_algorithm;
     copy->callback = orig->callback;
+	copy->user_data = orig->user_data;
+#ifndef FIXEDFANN
     copy->cascade_output_change_fraction = orig->cascade_output_change_fraction;
     copy->cascade_output_stagnation_epochs = orig->cascade_output_stagnation_epochs;
     copy->cascade_candidate_change_fraction = orig->cascade_candidate_change_fraction;
@@ -913,7 +915,6 @@ FANN_EXTERNAL struct fann* FANN_API fann_copy(struct fann* orig)
     copy->cascade_weight_multiplier = orig->cascade_weight_multiplier;
     copy->cascade_max_out_epochs = orig->cascade_max_out_epochs;
     copy->cascade_max_cand_epochs = orig->cascade_max_cand_epochs;
-	copy->user_data = orig->user_data;
 
    /* copy cascade activation functions */
     copy->cascade_activation_functions_count = orig->cascade_activation_functions_count;
@@ -958,6 +959,7 @@ FANN_EXTERNAL struct fann* FANN_API fann_copy(struct fann* orig)
         }
         memcpy(copy->cascade_candidate_scores,orig->cascade_candidate_scores,fann_get_cascade_num_candidates(copy) * sizeof(fann_type));
     }
+#endif /* FIXEDFANN */
 
     copy->quickprop_decay = orig->quickprop_decay;
     copy->quickprop_mu = orig->quickprop_mu;

--- a/src/include/fann_cascade.h
+++ b/src/include/fann_cascade.h
@@ -35,6 +35,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 /* Group: Cascade Training */
 
+#ifndef FIXEDFANN
 /* Function: fann_cascadetrain_on_data
 
    Trains on an entire dataset, for a period of time using the Cascade2 training algorithm.
@@ -555,5 +556,6 @@ FANN_EXTERNAL unsigned int FANN_API fann_get_cascade_num_candidate_groups(struct
 FANN_EXTERNAL void FANN_API fann_set_cascade_num_candidate_groups(struct fann *ann, 
 															 unsigned int cascade_num_candidate_groups);
 
+#endif // FIXEDFANN
 
 #endif

--- a/src/include/fann_cascade.h
+++ b/src/include/fann_cascade.h
@@ -556,6 +556,6 @@ FANN_EXTERNAL unsigned int FANN_API fann_get_cascade_num_candidate_groups(struct
 FANN_EXTERNAL void FANN_API fann_set_cascade_num_candidate_groups(struct fann *ann, 
 															 unsigned int cascade_num_candidate_groups);
 
-#endif // FIXEDFANN
+#endif  /* FIXEDFANN */
 
 #endif

--- a/src/include/fann_cpp.h
+++ b/src/include/fann_cpp.h
@@ -1860,6 +1860,7 @@ namespace FANN {
             return bit_fail;
         }
 
+#ifndef FIXEDFANN
         /*********************************************************************/
 
         /* Method: cascadetrain_on_data
@@ -2435,7 +2436,6 @@ namespace FANN {
 
         /*********************************************************************/
 
-#ifndef FIXEDFANN
 
         /* Method: scale_train
 

--- a/src/include/fann_training_data_cpp.h
+++ b/src/include/fann_training_data_cpp.h
@@ -449,7 +449,7 @@ namespace FANN {
         fann_type get_max_output() {
             return fann_get_max_train_output(train_data);
         }
-#endif // FIXEDFANN
+#endif /* FIXEDFANN */
 
         /* Method: scale_input_train_data
 

--- a/src/include/fann_training_data_cpp.h
+++ b/src/include/fann_training_data_cpp.h
@@ -409,6 +409,7 @@ namespace FANN {
             train_data = fann_create_train_from_callback(num_data, num_input, num_output, user_function);
         }
 
+#ifndef FIXEDFANN
         /* Function: get_min_input
 
            Get the minimum value of all in the input data
@@ -448,6 +449,7 @@ namespace FANN {
         fann_type get_max_output() {
             return fann_get_max_train_output(train_data);
         }
+#endif // FIXEDFANN
 
         /* Method: scale_input_train_data
 


### PR DESCRIPTION
I added a class that calls all the functions of fann, fann_data, fan_cpp and fann_training_data_cpp and I was getting linker errors due to cascade functions having a declaration but no implementation because they are hidden by #ifndef FIXEDFANN directives. I added similar directives to the header file, the code in fann_cpp that calls those functions, and the code in fann.c that calls those functions. Additionally, the get_min|max_input|output functions are hidden from FIXEDFANN, but they are still called in fann_training_data_cpp.h so I added ifndefs to that file to exclude those functions when FIXEDFANN is defined.