### PR TITLE
Fixed error where assert is not found when building xor_cpp_sample by…

### DIFF
--- a/src/include/fann_cpp.h
+++ b/src/include/fann_cpp.h
@@ -63,6 +63,7 @@
  *
  */
 
+#include <assert.h>
 #include <stdarg.h>
 #include <string>
 #include "fann_data_cpp.h"


### PR DESCRIPTION
… including assert.h

The xor_cpp_sample project was giving me errors about assert not being defined so I included assert.h in fann_cpp.h.