### PR TITLE
Removed set_callback and internal_callback for FIXEDFANN neural_nets

### DIFF
--- a/src/include/fann_cpp.h
+++ b/src/include/fann_cpp.h
@@ -867,6 +867,8 @@ namespace FANN {
             }
         }
 
+#ifndef FIXEDFANN
+
         /* Method: set_callback
            
            Sets the callback function for use during training. The user_data is passed to
@@ -898,6 +900,8 @@ namespace FANN {
                     fann_set_callback(ann, NULL);
             }
         }
+
+#endif  /* NOT FIXEDFANN */
 
         /* Method: print_parameters
 
@@ -2905,6 +2909,8 @@ namespace FANN {
             neural_net *net; // This pointer for the neural network
         } user_context;
 
+#ifndef FIXEDFANN
+
         // Internal callback used to convert from pointers to class references
         static int FANN_API internal_callback(struct fann *ann, struct fann_train_data *train,
                                               unsigned int max_epochs, unsigned int epochs_between_reports,
@@ -2925,6 +2931,8 @@ namespace FANN {
                 return -1; // This should not occur except if out of memory
             }
         }
+
+#endif  /* NOT FIXEDFANN */
 
     protected:
         // Pointer the encapsulated fann neural net structure


### PR DESCRIPTION
The callback is only used during training and fixed neural_nets don't do any training,  so the callback is irrelevant.