### PR TITLE
Remove errors from compiletest target and SPFP optimisation

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -48,7 +48,7 @@ rundebugtest: $(DEBUG_TARGETS)
 compiletest:
 	gcc -O3 -ggdb -DDISABLE_PARALLEL_FANN -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wshadow -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -std=c99 -I../src/ -I../src/include/ ../src/floatfann.c xor_train.c -o xor_train -lm
 	gcc -O3 -ggdb -DDISABLE_PARALLEL_FANN -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wshadow -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -std=c99 -DFIXEDFANN -I../src/ -I../src/include/ ../src/fixedfann.c xor_test.c -o xor_test -lm
-	g++ -O3 -ggdb -DDISABLE_PARALLEL_FANN -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -std=c99 -I../src/ -I../src/include/ ../src/floatfann.c xor_train.c -o xor_train -lm
+	gcc -O3 -ggdb -DDISABLE_PARALLEL_FANN -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -std=c99 -I../src/ -I../src/include/ ../src/floatfann.c xor_train.c -o xor_train -lm
 	g++ -O3 -ggdb -DDISABLE_PARALLEL_FANN -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -std=c++11 -I../src/ -I../src/include/ ../src/floatfann.c -lm xor_sample.cpp -o xor_train
 
 quickcompiletest:

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -46,13 +46,13 @@ rundebugtest: $(DEBUG_TARGETS)
 
 #compiletest is used to test whether the library will compile easily in other compilers
 compiletest:
-	gcc -O3 -ggdb -DDISABLE_PARALLEL_FANN -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wshadow -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -I../src/ -I../src/include/ ../src/floatfann.c xor_train.c -o xor_train -lm
-	gcc -O3 -ggdb -DDISABLE_PARALLEL_FANN -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wshadow -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -DFIXEDFANN -I../src/ -I../src/include/ ../src/fixedfann.c xor_test.c -o xor_test -lm
-	g++ -O3 -ggdb -DDISABLE_PARALLEL_FANN -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -I../src/ -I../src/include/ ../src/floatfann.c xor_train.c -o xor_train -lm
+	gcc -O3 -ggdb -DDISABLE_PARALLEL_FANN -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wshadow -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -std=c99 -I../src/ -I../src/include/ ../src/floatfann.c xor_train.c -o xor_train -lm
+	gcc -O3 -ggdb -DDISABLE_PARALLEL_FANN -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wshadow -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -std=c99 -DFIXEDFANN -I../src/ -I../src/include/ ../src/fixedfann.c xor_test.c -o xor_test -lm
+	g++ -O3 -ggdb -DDISABLE_PARALLEL_FANN -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -std=c99 -I../src/ -I../src/include/ ../src/floatfann.c xor_train.c -o xor_train -lm
 	g++ -O3 -ggdb -DDISABLE_PARALLEL_FANN -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -std=c++11 -I../src/ -I../src/include/ ../src/floatfann.c -lm xor_sample.cpp -o xor_train
 
 quickcompiletest:
-	gcc -O -ggdb -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wshadow -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -I../src/ -I../src/include/ ../src/floatfann.c ../examples/xor_train.c -o ../examples/xor_train -lm
+	gcc -O -ggdb -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wshadow -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -std=c99 -I../src/ -I../src/include/ ../src/floatfann.c ../examples/xor_train.c -o ../examples/xor_train -lm
 
 debug: $(DEBUG_TARGETS)
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -46,13 +46,13 @@ rundebugtest: $(DEBUG_TARGETS)
 
 #compiletest is used to test whether the library will compile easily in other compilers
 compiletest:
-	gcc -O3 -ggdb -DDISABLE_PARALLEL_FANN -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wshadow -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -ansi -I../src/ -I../src/include/ ../src/floatfann.c xor_train.c -o xor_train -lm
-	gcc -O3 -ggdb -DDISABLE_PARALLEL_FANN -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wshadow -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -ansi -DFIXEDFANN -I../src/ -I../src/include/ ../src/fixedfann.c xor_test.c -o xor_test -lm
-	g++ -O3 -ggdb -DDISABLE_PARALLEL_FANN -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -ansi -I../src/ -I../src/include/ ../src/floatfann.c xor_train.c -o xor_train -lm
-	g++ -O3 -ggdb -DDISABLE_PARALLEL_FANN -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -ansi -std=c++11 -I../src/ -I../src/include/ ../src/floatfann.c xor_sample.cpp -o xor_train -lm
+	gcc -O3 -ggdb -DDISABLE_PARALLEL_FANN -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wshadow -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -I../src/ -I../src/include/ ../src/floatfann.c xor_train.c -o xor_train -lm
+	gcc -O3 -ggdb -DDISABLE_PARALLEL_FANN -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wshadow -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -DFIXEDFANN -I../src/ -I../src/include/ ../src/fixedfann.c xor_test.c -o xor_test -lm
+	g++ -O3 -ggdb -DDISABLE_PARALLEL_FANN -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -I../src/ -I../src/include/ ../src/floatfann.c xor_train.c -o xor_train -lm
+	g++ -O3 -ggdb -DDISABLE_PARALLEL_FANN -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -std=c++11 -I../src/ -I../src/include/ ../src/floatfann.c -lm xor_sample.cpp -o xor_train
 
 quickcompiletest:
-	gcc -O -ggdb -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wshadow -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -ansi -I../src/ -I../src/include/ ../src/floatfann.c ../examples/xor_train.c -o ../examples/xor_train -lm
+	gcc -O -ggdb -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wshadow -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -I../src/ -I../src/include/ ../src/floatfann.c ../examples/xor_train.c -o ../examples/xor_train -lm
 
 debug: $(DEBUG_TARGETS)
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -49,15 +49,15 @@ compiletest:
 	gcc -O3 -ggdb -DDISABLE_PARALLEL_FANN -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wshadow -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -ansi -I../src/ -I../src/include/ ../src/floatfann.c xor_train.c -o xor_train -lm
 	gcc -O3 -ggdb -DDISABLE_PARALLEL_FANN -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wshadow -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -ansi -DFIXEDFANN -I../src/ -I../src/include/ ../src/fixedfann.c xor_test.c -o xor_test -lm
 	g++ -O3 -ggdb -DDISABLE_PARALLEL_FANN -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -ansi -I../src/ -I../src/include/ ../src/floatfann.c xor_train.c -o xor_train -lm
-	g++ -O3 -ggdb -DDISABLE_PARALLEL_FANN -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -ansi -I../src/ -I../src/include/ ../src/floatfann.c xor_sample.cpp -o xor_train -lm
+	g++ -O3 -ggdb -DDISABLE_PARALLEL_FANN -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -ansi -std=c++11 -I../src/ -I../src/include/ ../src/floatfann.c xor_sample.cpp -o xor_train -lm
 
 quickcompiletest:
-	gcc -O -ggdb -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wshadow -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -ansi -I../src/ -I../src/include/ ../src/floatfann.c ../examples/xor_train.c -o ../examples/xor_train -lm 
+	gcc -O -ggdb -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wshadow -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -ansi -I../src/ -I../src/include/ ../src/floatfann.c ../examples/xor_train.c -o ../examples/xor_train -lm
 
 debug: $(DEBUG_TARGETS)
 
 %_debug: %.c Makefile ../src/*c ../src/include/*h
-	$(GCC) -ggdb -DDEBUG -Wall -ansi -I../src/ -I../src/include/ ../src/floatfann.c $< -o $@ -lm 
+	$(GCC) -ggdb -DDEBUG -Wall -ansi -I../src/ -I../src/include/ ../src/floatfann.c $< -o $@ -lm
 
 %_fixed_debug: %.c Makefile ../src/*c ../src/include/*h
 	$(GCC) -ggdb -DDEBUG -Wall -ansi -DFIXEDFANN -I../src/ -I../src/include/ ../src/fixedfann.c $< -o $@ -lm

--- a/src/fann_io.c
+++ b/src/fann_io.c
@@ -1,17 +1,17 @@
 /*
   Fast Artificial Neural Network Library (fann)
   Copyright (C) 2003-2016 Steffen Nissen (steffen.fann@gmail.com)
-  
+
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
   License as published by the Free Software Foundation; either
   version 2.1 of the License, or (at your option) any later version.
-  
+
   This library is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
   Lesser General Public License for more details.
-  
+
   You should have received a copy of the GNU Lesser General Public
   License along with this library; if not, write to the Free Software
   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
@@ -179,7 +179,7 @@ int fann_save_internal_fd(struct fann *ann, FILE * conf, const char *configurati
 	fprintf(conf, "learning_rate=%f\n", ann->learning_rate);
 	fprintf(conf, "connection_rate=%f\n", ann->connection_rate);
 	fprintf(conf, "network_type=%u\n", ann->network_type);
-	
+
 	fprintf(conf, "learning_momentum=%f\n", ann->learning_momentum);
 	fprintf(conf, "training_algorithm=%u\n", ann->training_algorithm);
 	fprintf(conf, "train_error_function=%u\n", ann->train_error_function);
@@ -197,8 +197,8 @@ int fann_save_internal_fd(struct fann *ann, FILE * conf, const char *configurati
 	fprintf(conf, "cascade_candidate_stagnation_epochs=%u\n", ann->cascade_candidate_stagnation_epochs);
 	fprintf(conf, "cascade_max_out_epochs=%u\n", ann->cascade_max_out_epochs);
 	fprintf(conf, "cascade_min_out_epochs=%u\n", ann->cascade_min_out_epochs);
-	fprintf(conf, "cascade_max_cand_epochs=%u\n", ann->cascade_max_cand_epochs);	
-	fprintf(conf, "cascade_min_cand_epochs=%u\n", ann->cascade_min_cand_epochs);	
+	fprintf(conf, "cascade_max_cand_epochs=%u\n", ann->cascade_max_cand_epochs);
+	fprintf(conf, "cascade_min_cand_epochs=%u\n", ann->cascade_min_cand_epochs);
 	fprintf(conf, "cascade_num_candidate_groups=%u\n", ann->cascade_num_candidate_groups);
 
 #ifndef FIXEDFANN
@@ -209,11 +209,11 @@ int fann_save_internal_fd(struct fann *ann, FILE * conf, const char *configurati
 		fprintf(conf, "cascade_weight_multiplier=%u\n", (int) floor((ann->cascade_weight_multiplier * fixed_multiplier) + 0.5));
 	}
 	else
-#endif	
+#endif
 	{
-		fprintf(conf, "bit_fail_limit="FANNPRINTF"\n", ann->bit_fail_limit);
-		fprintf(conf, "cascade_candidate_limit="FANNPRINTF"\n", ann->cascade_candidate_limit);
-		fprintf(conf, "cascade_weight_multiplier="FANNPRINTF"\n", ann->cascade_weight_multiplier);
+		fprintf(conf, "bit_fail_limit=" FANNPRINTF"\n", ann->bit_fail_limit);
+		fprintf(conf, "cascade_candidate_limit=" FANNPRINTF"\n", ann->cascade_candidate_limit);
+		fprintf(conf, "cascade_weight_multiplier=" FANNPRINTF"\n", ann->cascade_weight_multiplier);
 	}
 
 	fprintf(conf, "cascade_activation_functions_count=%u\n", ann->cascade_activation_functions_count);
@@ -221,7 +221,7 @@ int fann_save_internal_fd(struct fann *ann, FILE * conf, const char *configurati
 	for(i = 0; i < ann->cascade_activation_functions_count; i++)
 		fprintf(conf, "%u ", ann->cascade_activation_functions[i]);
 	fprintf(conf, "\n");
-	
+
 	fprintf(conf, "cascade_activation_steepnesses_count=%u\n", ann->cascade_activation_steepnesses_count);
 	fprintf(conf, "cascade_activation_steepnesses=");
 	for(i = 0; i < ann->cascade_activation_steepnesses_count; i++)
@@ -230,7 +230,7 @@ int fann_save_internal_fd(struct fann *ann, FILE * conf, const char *configurati
 		if(save_as_fixed)
 			fprintf(conf, "%u ", (int) floor((ann->cascade_activation_steepnesses[i] * fixed_multiplier) + 0.5));
 		else
-#endif	
+#endif
 			fprintf(conf, FANNPRINTF" ", ann->cascade_activation_steepnesses[i]);
 	}
 	fprintf(conf, "\n");
@@ -260,7 +260,7 @@ int fann_save_internal_fd(struct fann *ann, FILE * conf, const char *configurati
 			SCALE_SAVE( scale_deviation,	in )
 			SCALE_SAVE( scale_new_min,		in )
 			SCALE_SAVE( scale_factor,		in )
-		
+
 			SCALE_SAVE( scale_mean,			out )
 			SCALE_SAVE( scale_deviation,	out )
 			SCALE_SAVE( scale_new_min,		out )
@@ -270,7 +270,7 @@ int fann_save_internal_fd(struct fann *ann, FILE * conf, const char *configurati
 			fprintf(conf, "scale_included=0\n");
 	}
 #undef SCALE_SAVE
-#endif	
+#endif
 
 	/* 2.0 */
 	fprintf(conf, "neurons (num_inputs, activation_function, activation_steepness)=");
@@ -306,7 +306,7 @@ int fann_save_internal_fd(struct fann *ann, FILE * conf, const char *configurati
 	/* Now save all the connections.
 	 * We only need to save the source and the weight,
 	 * since the destination is given by the order.
-	 * 
+	 *
 	 * The weight is not saved binary due to differences
 	 * in binary definition of floating point numbers.
 	 * Especially an iPAQ does not use the same binary
@@ -343,7 +343,7 @@ struct fann *fann_create_from_fd_1_1(FILE * conf, const char *configuration_file
 
 #define fann_scanf(type, name, val) \
 { \
-	if(fscanf(conf, name"="type"\n", val) != 1) \
+	if(fscanf(conf, name"=" type"\n", val) != 1) \
 	{ \
 		fann_error(NULL, FANN_E_CANT_READ_CONFIG, name, configuration_file); \
 		fann_destroy(ann); \
@@ -462,8 +462,8 @@ struct fann *fann_create_from_fd(FILE * conf, const char *configuration_file)
 	fann_scanf("%u", "cascade_candidate_stagnation_epochs", &ann->cascade_candidate_stagnation_epochs);
 	fann_scanf("%u", "cascade_max_out_epochs", &ann->cascade_max_out_epochs);
 	fann_scanf("%u", "cascade_min_out_epochs", &ann->cascade_min_out_epochs);
-	fann_scanf("%u", "cascade_max_cand_epochs", &ann->cascade_max_cand_epochs);	
-	fann_scanf("%u", "cascade_min_cand_epochs", &ann->cascade_min_cand_epochs);	
+	fann_scanf("%u", "cascade_max_cand_epochs", &ann->cascade_max_cand_epochs);
+	fann_scanf("%u", "cascade_min_cand_epochs", &ann->cascade_min_cand_epochs);
 	fann_scanf("%u", "cascade_num_candidate_groups", &ann->cascade_num_candidate_groups);
 
 	fann_scanf(FANNSCANF, "bit_fail_limit", &ann->bit_fail_limit);
@@ -474,8 +474,8 @@ struct fann *fann_create_from_fd(FILE * conf, const char *configuration_file)
 	fann_scanf("%u", "cascade_activation_functions_count", &ann->cascade_activation_functions_count);
 
 	/* reallocate mem */
-	ann->cascade_activation_functions = 
-		(enum fann_activationfunc_enum *)realloc(ann->cascade_activation_functions, 
+	ann->cascade_activation_functions =
+		(enum fann_activationfunc_enum *)realloc(ann->cascade_activation_functions,
 		ann->cascade_activation_functions_count * sizeof(enum fann_activationfunc_enum));
 	if(ann->cascade_activation_functions == NULL)
 	{
@@ -500,8 +500,8 @@ struct fann *fann_create_from_fd(FILE * conf, const char *configuration_file)
 	fann_scanf("%u", "cascade_activation_steepnesses_count", &ann->cascade_activation_steepnesses_count);
 
 	/* reallocate mem */
-	ann->cascade_activation_steepnesses = 
-		(fann_type *)realloc(ann->cascade_activation_steepnesses, 
+	ann->cascade_activation_steepnesses =
+		(fann_type *)realloc(ann->cascade_activation_steepnesses,
 		ann->cascade_activation_steepnesses_count * sizeof(fann_type));
 	if(ann->cascade_activation_steepnesses == NULL)
 	{
@@ -511,7 +511,7 @@ struct fann *fann_create_from_fd(FILE * conf, const char *configuration_file)
 	}
 
 	fann_skip("cascade_activation_steepnesses=");
-	for(i = 0; i < ann->cascade_activation_steepnesses_count; i++) 
+	for(i = 0; i < ann->cascade_activation_steepnesses_count; i++)
 	{
 		if(fscanf(conf, FANNSCANF" ", &ann->cascade_activation_steepnesses[i]) != 1)
 		{
@@ -582,7 +582,7 @@ struct fann *fann_create_from_fd(FILE * conf, const char *configuration_file)
 			return NULL;													\
 		}																	\
 	}
-	
+
 	if(fscanf(conf, "scale_included=%u\n", &scale_included) == 1 && scale_included == 1)
 	{
 		fann_allocate_scale(ann);
@@ -590,7 +590,7 @@ struct fann *fann_create_from_fd(FILE * conf, const char *configuration_file)
 		SCALE_LOAD( scale_deviation,	in )
 		SCALE_LOAD( scale_new_min,		in )
 		SCALE_LOAD( scale_factor,		in )
-	
+
 		SCALE_LOAD( scale_mean,			out )
 		SCALE_LOAD( scale_deviation,	out )
 		SCALE_LOAD( scale_new_min,		out )
@@ -598,7 +598,7 @@ struct fann *fann_create_from_fd(FILE * conf, const char *configuration_file)
 	}
 #undef SCALE_LOAD
 #endif
-	
+
 	/* allocate room for the actual neurons */
 	fann_allocate_neurons(ann);
 	if(ann->errno_f == FANN_E_CANT_ALLOCATE_MEM)

--- a/src/include/fann_activation.h
+++ b/src/include/fann_activation.h
@@ -20,14 +20,27 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #ifndef __fann_activation_h__
 #define __fann_activation_h__
 /* internal include file, not to be included directly
- */
+*/
 
 /* Implementation of the activation functions
- */
+*/
 
 /* stepwise linear functions used for some of the activation functions */
 
 /* defines used for the stepwise linear functions */
+
+/* Uses the single precision version of math.h functions if
+__doublefann_h__ is not defined
+*/
+#ifndef __doublefann_h__
+#define FANN_EXP(x) expf(x)
+#define FANN_SIN(x) sinf(x)
+#define FANN_COS(x) cosf(x)
+#else
+#define FANN_EXP(x) exp(x)
+#define FANN_SIN(x) sin(x)
+#define FANN_COS(x) cos(x)
+#endif
 
 #define fann_linear_func(v1, r1, v2, r2, sum) (((((r2)-(r1)) * ((sum)-(v1)))/((v2)-(v1))) + (r1))
 #define fann_stepwise(v1, v2, v3, v4, v5, v6, r1, r2, r3, r4, r5, r6, min, max, sum) (sum < v5 ? (sum < v3 ? (sum < v2 ? (sum < v1 ? min : fann_linear_func(v1, r1, v2, r2, sum)) : fann_linear_func(v2, r2, v3, r3, sum)) : (sum < v4 ? fann_linear_func(v3, r3, v4, r4, sum) : fann_linear_func(v4, r4, v5, r5, sum))) : (sum < v6 ? fann_linear_func(v5, r5, v6, r6, sum) : max))
@@ -38,22 +51,22 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 /* FANN_SIGMOID */
 /* #define fann_sigmoid(steepness, sum) (1.0f/(1.0f + exp(-2.0f * steepness * sum))) */
-#define fann_sigmoid_real(sum) (1.0f/(1.0f + exp(-2.0f * sum)))
+#define fann_sigmoid_real(sum) (1.0f/(1.0f + FANN_EXP(-2.0f * sum)))
 #define fann_sigmoid_derive(steepness, value) (2.0f * steepness * value * (1.0f - value))
 
 /* FANN_SIGMOID_SYMMETRIC */
 /* #define fann_sigmoid_symmetric(steepness, sum) (2.0f/(1.0f + exp(-2.0f * steepness * sum)) - 1.0f) */
-#define fann_sigmoid_symmetric_real(sum) (2.0f/(1.0f + exp(-2.0f * sum)) - 1.0f)
+#define fann_sigmoid_symmetric_real(sum) (2.0f/(1.0f + FANN_EXP(-2.0f * sum)) - 1.0f)
 #define fann_sigmoid_symmetric_derive(steepness, value) steepness * (1.0f - (value*value))
 
 /* FANN_GAUSSIAN */
 /* #define fann_gaussian(steepness, sum) (exp(-sum * steepness * sum * steepness)) */
-#define fann_gaussian_real(sum) (exp(-sum * sum))
+#define fann_gaussian_real(sum) (FANN_EXP(-sum * sum))
 #define fann_gaussian_derive(steepness, value, sum) (-2.0f * sum * value * steepness * steepness)
 
 /* FANN_GAUSSIAN_SYMMETRIC */
 /* #define fann_gaussian_symmetric(steepness, sum) ((exp(-sum * steepness * sum * steepness)*2.0)-1.0) */
-#define fann_gaussian_symmetric_real(sum) ((exp(-sum * sum)*2.0f)-1.0f)
+#define fann_gaussian_symmetric_real(sum) ((FANN_EXP(-sum * sum)*2.0f)-1.0f)
 #define fann_gaussian_symmetric_derive(steepness, value, sum) (-2.0f * sum * (value+1.0f) * steepness * steepness)
 
 /* FANN_ELLIOT */
@@ -67,19 +80,19 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #define fann_elliot_symmetric_derive(steepness, value, sum) (steepness * 1.0f / ((1.0f + fann_abs(sum)) * (1.0f + fann_abs(sum))))
 
 /* FANN_SIN_SYMMETRIC */
-#define fann_sin_symmetric_real(sum) (sin(sum))
+#define fann_sin_symmetric_real(sum) (FANN_SIN(sum))
 #define fann_sin_symmetric_derive(steepness, sum) (steepness*cos(steepness*sum))
 
 /* FANN_COS_SYMMETRIC */
-#define fann_cos_symmetric_real(sum) (cos(sum))
+#define fann_cos_symmetric_real(sum) (FANN_COS(sum))
 #define fann_cos_symmetric_derive(steepness, sum) (steepness*-sin(steepness*sum))
 
 /* FANN_SIN */
-#define fann_sin_real(sum) (sin(sum)/2.0f+0.5f)
+#define fann_sin_real(sum) (FANN_SIN(sum)/2.0f+0.5f)
 #define fann_sin_derive(steepness, sum) (steepness*cos(steepness*sum)/2.0f)
 
 /* FANN_COS */
-#define fann_cos_real(sum) (cos(sum)/2.0f+0.5f)
+#define fann_cos_real(sum) (FANN_COS(sum)/2.0f+0.5f)
 #define fann_cos_derive(steepness, sum) (steepness*-sin(steepness*sum)/2.0f)
 
 #define fann_activation_switch(activation_function, value, result) \
@@ -101,10 +114,10 @@ switch(activation_function) \
 		result = (fann_type)fann_sigmoid_symmetric_real(value); \
         break; \
 	case FANN_SIGMOID_SYMMETRIC_STEPWISE: \
-		result = (fann_type)fann_stepwise(-2.64665293693542480469e+00, -1.47221934795379638672e+00, -5.49306154251098632812e-01, 5.49306154251098632812e-01, 1.47221934795379638672e+00, 2.64665293693542480469e+00, -9.90000009536743164062e-01, -8.99999976158142089844e-01, -5.00000000000000000000e-01, 5.00000000000000000000e-01, 8.99999976158142089844e-01, 9.90000009536743164062e-01, -1, 1, value); \
+		result = (fann_type)fann_stepwise(((fann_type)-2.64665293693542480469e+00), ((fann_type)-1.47221934795379638672e+00), ((fann_type)-5.49306154251098632812e-01), ((fann_type)5.49306154251098632812e-01), ((fann_type)1.47221934795379638672e+00), ((fann_type)2.64665293693542480469e+00), ((fann_type)-9.90000009536743164062e-01), ((fann_type)-8.99999976158142089844e-01), ((fann_type)-5.00000000000000000000e-01), ((fann_type)5.00000000000000000000e-01), ((fann_type)8.99999976158142089844e-01), ((fann_type)9.90000009536743164062e-01), -1, 1, value); \
         break; \
 	case FANN_SIGMOID_STEPWISE: \
-		result = (fann_type)fann_stepwise(-2.64665246009826660156e+00, -1.47221946716308593750e+00, -5.49306154251098632812e-01, 5.49306154251098632812e-01, 1.47221934795379638672e+00, 2.64665293693542480469e+00, 4.99999988824129104614e-03, 5.00000007450580596924e-02, 2.50000000000000000000e-01, 7.50000000000000000000e-01, 9.49999988079071044922e-01, 9.95000004768371582031e-01, 0, 1, value); \
+		result = (fann_type)fann_stepwise(((fann_type)-2.64665246009826660156e+00), ((fann_type)-1.47221946716308593750e+00), ((fann_type)-5.49306154251098632812e-01), ((fann_type)5.49306154251098632812e-01), ((fann_type)1.47221934795379638672e+00), ((fann_type)2.64665293693542480469e+00), ((fann_type) 4.99999988824129104614e-03), ((fann_type) 5.00000007450580596924e-02), ((fann_type) 2.50000000000000000000e-01), ((fann_type)7.50000000000000000000e-01), ((fann_type)9.49999988079071044922e-01), ((fann_type)9.95000004768371582031e-01), 0, 1, value); \
         break; \
 	case FANN_THRESHOLD: \
 		result = (fann_type)((value < 0) ? 0 : 1); \


### PR DESCRIPTION
Sorry, should be two pull requests but this is my first one and I did not separate the commits.
Also apologies for my editor removing spurious spaces automatically - need to find how to turn that off.

I have removed the errors from the compiletest build targets by adding the standards that the code conforms to to the build options.

I have also removed some of the double precision math that get pulled into the activation functions even in single precision mode.

Minor changes if the intent is agreeable.
See comments for intent.
