### PR TITLE
Update in fann_error.c to exit in case of error.

### DIFF
--- a/src/fann_error.c
+++ b/src/fann_error.c
@@ -214,6 +214,8 @@ void fann_error(struct fann_error *errdat, const enum fann_errno_enum errno_f, .
 	{
 		fprintf(error_log, "FANN Error %d: %s", errno_f, errstr);
 	}
+	
+	exit(1);
 }
 
 /* INTERNAL FUNCTION


### PR DESCRIPTION
Update in fann_error.c to exit in case of error. This is necessary when using fann in a genetic algorithm, for exemple; i.e. when fann is invoked many times from a script that needs to know if it failed.