### PR TITLE
change example Makefile to have separate CFLAGS+LDFLAGS

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,6 +1,8 @@
 # The makefile requires that the fann library has been built first and is either in the
 
-GCC=gcc -I ../src/include -L ../src/
+GCC=gcc
+CFLAGS=-I ../src/include
+LDFLAGS=-L ../src/
 
 TARGETS = xor_train xor_test xor_test_fixed simple_train steepness_train simple_test robot mushroom cascade_train scaling_test scaling_train
 DEBUG_TARGETS = xor_train_debug xor_test_debug xor_test_fixed_debug cascade_train_debug
@@ -8,10 +10,10 @@ DEBUG_TARGETS = xor_train_debug xor_test_debug xor_test_fixed_debug cascade_trai
 all: $(TARGETS)
 
 %: %.c Makefile
-	$(GCC) -O3 $< -o $@ -lfann -lm
+	$(GCC) $(CFLAGS) $(LDFLAGS) -O3 $< -o $@ -lfann -lm
 
 %_fixed: %.c Makefile
-	$(GCC) -O3 -DFIXEDFANN $< -o $@ -lfixedfann -lm
+	$(GCC) $(CFLAGS) $(LDFLAGS) -O3 -DFIXEDFANN $< -o $@ -lfixedfann -lm
 
 clean:
 	rm -f $(TARGETS) $(DEBUG_TARGETS) xor_fixed.data *.net *~ *.obj *.exe *.tds noscale.txt withscale.txt scale_test_results.txt
@@ -52,15 +54,15 @@ compiletest:
 	g++ -O3 -ggdb -DDISABLE_PARALLEL_FANN -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -ansi -I../src/ -I../src/include/ ../src/floatfann.c xor_sample.cpp -o xor_train -lm
 
 quickcompiletest:
-	gcc -O -ggdb -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wshadow -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -ansi -I../src/ -I../src/include/ ../src/floatfann.c ../examples/xor_train.c -o ../examples/xor_train -lm 
+	gcc -O -ggdb -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wshadow -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -ansi -I../src/ -I../src/include/ ../src/floatfann.c ../examples/xor_train.c -o ../examples/xor_train -lm
 
 debug: $(DEBUG_TARGETS)
 
 %_debug: %.c Makefile ../src/*c ../src/include/*h
-	$(GCC) -ggdb -DDEBUG -Wall -ansi -I../src/ -I../src/include/ ../src/floatfann.c $< -o $@ -lm 
+	$(GCC) $(CFLAGS) $(LDFLAGS) -ggdb -DDEBUG -Wall -ansi -I../src/ ../src/floatfann.c $< -o $@ -lm
 
 %_fixed_debug: %.c Makefile ../src/*c ../src/include/*h
-	$(GCC) -ggdb -DDEBUG -Wall -ansi -DFIXEDFANN -I../src/ -I../src/include/ ../src/fixedfann.c $< -o $@ -lm
+	$(GCC) $(CFLAGS) $(LDFLAGS) -ggdb -DDEBUG -Wall -ansi -DFIXEDFANN -I../src/ ../src/fixedfann.c $< -o $@ -lm
 
 rundebug: $(DEBUG_TARGETS)
 	@echo


### PR DESCRIPTION
improves on commit 12f88446ed
allows to override pathes individually
This helps when building in a separate 'build' dir as we do in https://build.opensuse.org/package/view_file/devel:libraries:c_c++/fann/fann.spec