### PR TITLE
fix build fail of example

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -48,8 +48,8 @@ rundebugtest: $(DEBUG_TARGETS)
 compiletest:
 	gcc -O3 -ggdb -DDISABLE_PARALLEL_FANN -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wshadow -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -ansi -I../src/ -I../src/include/ ../src/floatfann.c xor_train.c -o xor_train -lm
 	gcc -O3 -ggdb -DDISABLE_PARALLEL_FANN -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wshadow -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -ansi -DFIXEDFANN -I../src/ -I../src/include/ ../src/fixedfann.c xor_test.c -o xor_test -lm
-	g++ -O3 -ggdb -DDISABLE_PARALLEL_FANN -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -ansi -I../src/ -I../src/include/ ../src/floatfann.c xor_train.c -o xor_train -lm
-	g++ -O3 -ggdb -DDISABLE_PARALLEL_FANN -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -ansi -I../src/ -I../src/include/ ../src/floatfann.c xor_sample.cpp -o xor_train -lm
+	g++ -O3 -ggdb -DDISABLE_PARALLEL_FANN -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -std=c++11 -I../src/ -I../src/include/ ../src/floatfann.c xor_train.c -o xor_train -lm
+	g++ -O3 -ggdb -DDISABLE_PARALLEL_FANN -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -std=c++11 -I../src/ -I../src/include/ ../src/floatfann.c xor_sample.cpp -o xor_train -lm
 
 quickcompiletest:
 	gcc -O -ggdb -DDEBUG -Wall -Wformat-security -Wfloat-equal -Wshadow -Wpointer-arith -Wcast-qual -Wsign-compare -pedantic -ansi -I../src/ -I../src/include/ ../src/floatfann.c ../examples/xor_train.c -o ../examples/xor_train -lm 

--- a/src/fann_io.c
+++ b/src/fann_io.c
@@ -211,9 +211,9 @@ int fann_save_internal_fd(struct fann *ann, FILE * conf, const char *configurati
 	else
 #endif	
 	{
-		fprintf(conf, "bit_fail_limit="FANNPRINTF"\n", ann->bit_fail_limit);
-		fprintf(conf, "cascade_candidate_limit="FANNPRINTF"\n", ann->cascade_candidate_limit);
-		fprintf(conf, "cascade_weight_multiplier="FANNPRINTF"\n", ann->cascade_weight_multiplier);
+		fprintf(conf, "bit_fail_limit=" FANNPRINTF "\n", ann->bit_fail_limit);
+		fprintf(conf, "cascade_candidate_limit=" FANNPRINTF "\n", ann->cascade_candidate_limit);
+		fprintf(conf, "cascade_weight_multiplier=" FANNPRINTF "\n", ann->cascade_weight_multiplier);
 	}
 
 	fprintf(conf, "cascade_activation_functions_count=%u\n", ann->cascade_activation_functions_count);
@@ -343,7 +343,7 @@ struct fann *fann_create_from_fd_1_1(FILE * conf, const char *configuration_file
 
 #define fann_scanf(type, name, val) \
 { \
-	if(fscanf(conf, name"="type"\n", val) != 1) \
+	if(fscanf(conf, name "=" type "\n", val) != 1) \
 	{ \
 		fann_error(NULL, FANN_E_CANT_READ_CONFIG, name, configuration_file); \
 		fann_destroy(ann); \


### PR DESCRIPTION
Fix example's compiletest.
+ add C++11 option for g++. Because of using unique_ptr.
+ add space for macro. When using C++11,
  need space between macro and literal. Because of confusing User-defined literals.