### PR TITLE
Catch zero standard deviation in data scaling logic.

### DIFF
--- a/src/fann_train_data.c
+++ b/src/fann_train_data.c
@@ -1027,14 +1027,15 @@ FANN_EXTERNAL void FANN_API fann_scale_input( struct fann *ann, fann_type *input
 	}
 	
 	for( cur_neuron = 0; cur_neuron < ann->num_input; cur_neuron++ )
-		input_vector[ cur_neuron ] =
-			(
-				( input_vector[ cur_neuron ] - ann->scale_mean_in[ cur_neuron ] )
-				/ ann->scale_deviation_in[ cur_neuron ]
-				- ( (fann_type)-1.0 ) /* This is old_min */
-			)
-			* ann->scale_factor_in[ cur_neuron ]
-			+ ann->scale_new_min_in[ cur_neuron ];
+                if(ann->scale_deviation_in[ cur_neuron ] != 0.0)
+                        input_vector[ cur_neuron ] =
+                                (
+                                        ( input_vector[ cur_neuron ] - ann->scale_mean_in[ cur_neuron ] )
+                                        / ann->scale_deviation_in[ cur_neuron ]
+                                        - ( (fann_type)-1.0 ) /* This is old_min */
+                                )
+                                * ann->scale_factor_in[ cur_neuron ]
+                                + ann->scale_new_min_in[ cur_neuron ];
 }
 
 /*
@@ -1050,14 +1051,15 @@ FANN_EXTERNAL void FANN_API fann_scale_output( struct fann *ann, fann_type *outp
 	}
 
 	for( cur_neuron = 0; cur_neuron < ann->num_output; cur_neuron++ )
-		output_vector[ cur_neuron ] =
-			(
-				( output_vector[ cur_neuron ] - ann->scale_mean_out[ cur_neuron ] )
-				/ ann->scale_deviation_out[ cur_neuron ]
-				- ( (fann_type)-1.0 ) /* This is old_min */
-			)
-			* ann->scale_factor_out[ cur_neuron ]
-			+ ann->scale_new_min_out[ cur_neuron ];
+                if(ann->scale_deviation_out[ cur_neuron ] != 0.0)
+                        output_vector[ cur_neuron ] =
+                                (
+                                        ( output_vector[ cur_neuron ] - ann->scale_mean_out[ cur_neuron ] )
+                                        / ann->scale_deviation_out[ cur_neuron ]
+                                        - ( (fann_type)-1.0 ) /* This is old_min */
+                                )
+                                * ann->scale_factor_out[ cur_neuron ]
+                                + ann->scale_new_min_out[ cur_neuron ];
 }
 
 /*
@@ -1073,17 +1075,18 @@ FANN_EXTERNAL void FANN_API fann_descale_input( struct fann *ann, fann_type *inp
 	}
 
 	for( cur_neuron = 0; cur_neuron < ann->num_input; cur_neuron++ )
-		input_vector[ cur_neuron ] =
-			(
-				(
-					input_vector[ cur_neuron ]
-					- ann->scale_new_min_in[ cur_neuron ]
-				)
-				/ ann->scale_factor_in[ cur_neuron ]
-				+ ( (fann_type)-1.0 ) /* This is old_min */
-			)
-			* ann->scale_deviation_in[ cur_neuron ]
-			+ ann->scale_mean_in[ cur_neuron ];
+                if(ann->scale_deviation_in[ cur_neuron ] != 0.0)
+                        input_vector[ cur_neuron ] =
+                                (
+                                        (
+                                                input_vector[ cur_neuron ]
+                                                - ann->scale_new_min_in[ cur_neuron ]
+                                        )
+                                        / ann->scale_factor_in[ cur_neuron ]
+                                        + ( (fann_type)-1.0 ) /* This is old_min */
+                                )
+                                * ann->scale_deviation_in[ cur_neuron ]
+                                + ann->scale_mean_in[ cur_neuron ];
 }
 
 /*
@@ -1099,17 +1102,18 @@ FANN_EXTERNAL void FANN_API fann_descale_output( struct fann *ann, fann_type *ou
 	}
 
 	for( cur_neuron = 0; cur_neuron < ann->num_output; cur_neuron++ )
-		output_vector[ cur_neuron ] =
-			(
-				(
-					output_vector[ cur_neuron ]
-					- ann->scale_new_min_out[ cur_neuron ]
-				)
-				/ ann->scale_factor_out[ cur_neuron ]
-				+ ( (fann_type)-1.0 ) /* This is old_min */
-			)
-			* ann->scale_deviation_out[ cur_neuron ]
-			+ ann->scale_mean_out[ cur_neuron ];
+                if(ann->scale_deviation_out[ cur_neuron ] != 0.0)
+                        output_vector[ cur_neuron ] =
+                                (
+                                        (
+                                                output_vector[ cur_neuron ]
+                                                - ann->scale_new_min_out[ cur_neuron ]
+                                        )
+                                        / ann->scale_factor_out[ cur_neuron ]
+                                        + ( (fann_type)-1.0 ) /* This is old_min */
+                                )
+                                * ann->scale_deviation_out[ cur_neuron ]
+                                + ann->scale_mean_out[ cur_neuron ];
 }
 
 /*

--- a/tests/fann_test_data.cpp
+++ b/tests/fann_test_data.cpp
@@ -160,7 +160,7 @@ TEST_F(FannTestData, ScaleData) {
     }
 
     EXPECT_DOUBLE_EQ(-1.0, data.get_train_output(0)[0]);
-    EXPECT_DOUBLE_EQ(2.0, data.get_train_output(0)[1]);
+    EXPECT_DOUBLE_EQ(2.0, data.get_train_output(1)[0]);
 
 }
 

--- a/tests/fann_test_data.cpp
+++ b/tests/fann_test_data.cpp
@@ -164,3 +164,24 @@ TEST_F(FannTestData, ScaleData) {
 
 }
 
+TEST_F(FannTestData, ScaleDataByANN) {
+    // Input 0, input 1, and the output are scaled normally. Input 2
+    // has a standard deviation of 0 and so is not scaled at all.
+    fann_type input[] = {0.0, 1.0, 0.5, 1.0, 2.0, 0.5};
+    fann_type output[] = {0.0, 1.5};
+    data.set_train_data(2, 3, input, 1, output);
+
+    neural_net net(LAYER, 2, 3, 1);
+    net.set_scaling_params(data, -1.0, 1.0, 0.0, 1.0);
+    net.scale_train(data);
+
+    EXPECT_DOUBLE_EQ(-1.0, data.get_train_input(0)[0]);
+    EXPECT_DOUBLE_EQ(-1.0, data.get_train_input(0)[1]);
+    EXPECT_DOUBLE_EQ(0.5, data.get_train_input(0)[2]);
+    EXPECT_DOUBLE_EQ(0.0, data.get_train_output(0)[0]);
+
+    EXPECT_DOUBLE_EQ(1.0, data.get_train_input(1)[0]);
+    EXPECT_DOUBLE_EQ(1.0, data.get_train_input(1)[1]);
+    EXPECT_DOUBLE_EQ(0.5, data.get_train_input(1)[2]);
+    EXPECT_DOUBLE_EQ(1.0, data.get_train_output(1)[0]);
+}


### PR DESCRIPTION
Closes #99.

Contrary to the suggestion given by the @charlie5, I decided to put the check to where the standard deviation is calculated, not where the scaling happens. This way, we handle both scaling and descaling in one go.

I set the standard deviation from zero to one so that there is still *some* sort of scaling happening. I guess another option would be to just return some form of error on zero.