### PR TITLE
Fix null checks in fann_scale_output and fann_descale_output.

### DIFF
--- a/src/fann_train_data.c
+++ b/src/fann_train_data.c
@@ -1122,7 +1122,7 @@ FANN_EXTERNAL void FANN_API fann_descale_output( struct fann *ann, fann_type *ou
 FANN_EXTERNAL void FANN_API fann_scale_train( struct fann *ann, struct fann_train_data *data )
 {
 	unsigned cur_sample;
-	if(ann->scale_mean_in == NULL)
+	if(ann->scale_mean_in == NULL || ann->scale_mean_out == NULL)
 	{
 		fann_error( (struct fann_error *) ann, FANN_E_SCALE_NOT_PRESENT );
 		return;
@@ -1144,7 +1144,7 @@ FANN_EXTERNAL void FANN_API fann_scale_train( struct fann *ann, struct fann_trai
 FANN_EXTERNAL void FANN_API fann_descale_train( struct fann *ann, struct fann_train_data *data )
 {
 	unsigned cur_sample;
-	if(ann->scale_mean_in == NULL)
+	if(ann->scale_mean_in == NULL || ann->scale_mean_out == NULL)
 	{
 		fann_error( (struct fann_error *) ann, FANN_E_SCALE_NOT_PRESENT );
 		return;

--- a/src/fann_train_data.c
+++ b/src/fann_train_data.c
@@ -1044,7 +1044,7 @@ FANN_EXTERNAL void FANN_API fann_scale_input( struct fann *ann, fann_type *input
 FANN_EXTERNAL void FANN_API fann_scale_output( struct fann *ann, fann_type *output_vector )
 {
 	unsigned cur_neuron;
-	if(ann->scale_mean_in == NULL)
+	if(ann->scale_mean_out == NULL)
 	{
 		fann_error( (struct fann_error *) ann, FANN_E_SCALE_NOT_PRESENT );
 		return;
@@ -1095,7 +1095,7 @@ FANN_EXTERNAL void FANN_API fann_descale_input( struct fann *ann, fann_type *inp
 FANN_EXTERNAL void FANN_API fann_descale_output( struct fann *ann, fann_type *output_vector )
 {
 	unsigned cur_neuron;
-	if(ann->scale_mean_in == NULL)
+	if(ann->scale_mean_out == NULL)
 	{
 		fann_error( (struct fann_error *) ann, FANN_E_SCALE_NOT_PRESENT );
 		return;

--- a/tests/fann_test_data.cpp
+++ b/tests/fann_test_data.cpp
@@ -199,12 +199,16 @@ TEST_F(FannTestData, ScaleDataByANNError) {
 
     net.scale_input(input);
     EXPECT_EQ(net.get_errno(), fann_errno_enum::FANN_E_SCALE_NOT_PRESENT);
+    EXPECT_EQ(input[0], 0.0);
+    EXPECT_EQ(input[1], 1.0);
+    EXPECT_EQ(input[2], 0.5);
 
     net.reset_errno();
     EXPECT_EQ(net.get_errno(), fann_errno_enum::FANN_E_NO_ERROR);
 
     net.scale_output(output);
     EXPECT_EQ(net.get_errno(), fann_errno_enum::FANN_E_SCALE_NOT_PRESENT);
+    EXPECT_EQ(output[0], 1.5);
 
     net.reset_errno();
     EXPECT_EQ(net.get_errno(), fann_errno_enum::FANN_E_NO_ERROR);
@@ -212,4 +216,8 @@ TEST_F(FannTestData, ScaleDataByANNError) {
     data.set_train_data(1, 3, input, 1, output);
     net.scale_train(data);
     EXPECT_EQ(net.get_errno(), fann_errno_enum::FANN_E_SCALE_NOT_PRESENT);
+    EXPECT_EQ(data.get_input()[0][0], 0.0);
+    EXPECT_EQ(data.get_input()[0][1], 1.0);
+    EXPECT_EQ(data.get_input()[0][2], 0.5);
+    EXPECT_EQ(data.get_output()[0][0], 1.5);
 }

--- a/tests/fann_test_data.cpp
+++ b/tests/fann_test_data.cpp
@@ -1,4 +1,5 @@
 #include "fann_test_data.h"
+#include "fann_error.h"
 
 void FannTestData::SetUp() {
     FannTest::SetUp();
@@ -184,4 +185,31 @@ TEST_F(FannTestData, ScaleDataByANN) {
     EXPECT_DOUBLE_EQ(1.0, data.get_train_input(1)[1]);
     EXPECT_DOUBLE_EQ(0.5, data.get_train_input(1)[2]);
     EXPECT_DOUBLE_EQ(1.0, data.get_train_output(1)[0]);
+}
+
+TEST_F(FannTestData, ScaleDataByANNError) {
+    // Scaling without setting the scaling parameters should error.
+    fann_type input[] = {0.0, 1.0, 0.5};
+    fann_type output[] = {1.5};
+
+    neural_net net(LAYER, 2, 3, 1);
+
+    // Silence error messages.
+    net.set_error_log(nullptr);
+
+    net.scale_input(input);
+    EXPECT_EQ(net.get_errno(), fann_errno_enum::FANN_E_SCALE_NOT_PRESENT);
+
+    net.reset_errno();
+    EXPECT_EQ(net.get_errno(), fann_errno_enum::FANN_E_NO_ERROR);
+
+    net.scale_output(output);
+    EXPECT_EQ(net.get_errno(), fann_errno_enum::FANN_E_SCALE_NOT_PRESENT);
+
+    net.reset_errno();
+    EXPECT_EQ(net.get_errno(), fann_errno_enum::FANN_E_NO_ERROR);
+
+    data.set_train_data(1, 3, input, 1, output);
+    net.scale_train(data);
+    EXPECT_EQ(net.get_errno(), fann_errno_enum::FANN_E_SCALE_NOT_PRESENT);
 }


### PR DESCRIPTION
These functions checked `scale_mean_in` for null, but then proceeded to
use `scale_mean_out`. This was not problematic (since both are always
allocated in tandem), but highly illogical.

Closes #108.