### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ After that, you'll need to use elevated privileges to install the library:
 
 That's it! If everything went right, you should see a lot of text, and FANN should be installed!
 
+### Building fann - Using vcpkg
+
+You can download and install fann using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install fann
+
+The fann port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## To Learn More
 
 To get started with FANN, go to the [FANN help site](http://leenissen.dk/fann/wp/help/), which will include links to all the available resources. 


### PR DESCRIPTION
Fann is available as a port in vcpkg, a C++ library manager that simplifies installation for fann and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build fann, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.